### PR TITLE
Enable GKE execution for Dagster

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ saltwater-intrusion-mapping/
 │ └── data/ # generated rasters (git-ignored)
 ├── notebooks/ # experiments / visual demos
 ├── pipeline_runner.py # legacy CLI (still works)
-├── dagster.yaml # local dev instance
+├── dagster.yaml # local dev instance (optional)
 ├── dagster_gke.yaml # run launcher for GKE
-├── workspace.yaml # loads swmaps.defs
+├── workspace.yaml # loads swmaps.defs (from __init__.py)
 ├── workspace_gke.yaml # loads swmaps.gke_defs
 └── pyproject.toml
 ```
@@ -97,6 +97,7 @@ pip install -e .
 # 2 · Launch Dagster UI (with queued run-coordinator)
 export DAGSTER_HOME="$(pwd)/.dagster_home"
 dagster dev -w workspace.yaml   # → http://localhost:3000
+# (the dagster.yaml file is optional; Dagster will fall back to defaults)
 
 # 3 · Materialise water masks
 #     (UI → Assets → masks_by_range → Launch backfill)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ saltwater-intrusion-mapping/
 ├── notebooks/ # experiments / visual demos
 ├── pipeline_runner.py # legacy CLI (still works)
 ├── dagster.yaml # local dev instance
+├── dagster_gke.yaml # run launcher for GKE
 ├── workspace.yaml # loads swmaps.defs
+├── workspace_gke.yaml # loads swmaps.gke_defs
 └── pyproject.toml
 ```
 
@@ -102,8 +104,21 @@ dagster dev -w workspace.yaml   # → http://localhost:3000
 > Smoketest: run without Dagster
 > `python pipeline_runner.py --step 0 --inline_mask`
 
+## 🚀 Running on GKE
+The repository includes a `dagster_gke.yaml` configuration that launches each
+Dagster run as a Kubernetes job. After building a container image for the
+`swmaps` package, point your deployment at this config file:
+
+```bash
+kubectl create namespace dagster
+export DAGSTER_HOME=/opt/dagster
+dagster api grpc -m swmaps.gke_defs &
+dagster-webserver -y dagster_gke.yaml -w workspace_gke.yaml
+```
+
 ---
 
 ## 📖 License
 
 MIT License
+

--- a/dagster.yaml
+++ b/dagster.yaml
@@ -1,0 +1,3 @@
+run_coordinator:
+  module: dagster.core.run_coordinator
+  class: QueuedRunCoordinator

--- a/dagster_gke.yaml
+++ b/dagster_gke.yaml
@@ -1,0 +1,14 @@
+run_coordinator:
+  module: dagster.core.run_coordinator
+  class: QueuedRunCoordinator
+  config:
+    max_concurrent_runs: 10
+
+run_launcher:
+  module: dagster_k8s.launcher
+  class: K8sRunLauncher
+  config:
+    job_image: ghcr.io/example/swmaps:latest
+    load_incluster_config: true
+    job_namespace: default
+    service_account_name: dagster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [project]
 name = "swmaps"
 version = "0.1.0"
-dependencies = []
+dependencies = [
+    "dagster",
+    "dagster-k8s",
+    "dagster-gcp[gcs]",
+]
 
 [tool.setuptools]
 packages = ["swmaps"]
-

--- a/swmaps/__init__.py
+++ b/swmaps/__init__.py
@@ -5,16 +5,9 @@ from dagster import Definitions, fs_io_manager
 from .pipelines.assets import download_range, masks_by_range
 from .pipelines.resources import data_root_res
 
+# Expose all pipeline assets for local execution with a filesystem IO manager.
 defs = Definitions(
-    assets=[masks_by_range],
-    resources={
-        "data_root": data_root_res,
-        "local_files": fs_io_manager,
-    },
-)
-
-defs = Definitions(
-    assets=[download_range],
+    assets=[download_range, masks_by_range],
     resources={
         "data_root": data_root_res,
         "local_files": fs_io_manager,

--- a/swmaps/gke_defs.py
+++ b/swmaps/gke_defs.py
@@ -3,11 +3,12 @@
 from dagster import Definitions
 from dagster_gcp.gcs import gcs_pickle_io_manager
 
-from .pipelines.assets import masks_by_range
+from .pipelines.assets import download_range, masks_by_range
 from .pipelines.resources import data_root_res
 
+# Same assets as ``swmaps.defs`` but with a GCS-backed IO manager for cloud runs.
 defs = Definitions(
-    assets=[masks_by_range],
+    assets=[download_range, masks_by_range],
     resources={
         "data_root": data_root_res,
         "local_files": gcs_pickle_io_manager,

--- a/swmaps/gke_defs.py
+++ b/swmaps/gke_defs.py
@@ -1,0 +1,15 @@
+"""Dagster Definitions configured for GKE."""
+
+from dagster import Definitions
+from dagster_gcp.gcs import gcs_pickle_io_manager
+
+from .pipelines.assets import masks_by_range
+from .pipelines.resources import data_root_res
+
+defs = Definitions(
+    assets=[masks_by_range],
+    resources={
+        "data_root": data_root_res,
+        "local_files": gcs_pickle_io_manager,
+    },
+)

--- a/workspace_gke.yaml
+++ b/workspace_gke.yaml
@@ -1,0 +1,4 @@
+load_from:
+  - python_module:
+      module_name: swmaps.gke_defs
+      attribute: defs


### PR DESCRIPTION
## Summary
- add Dagster dependencies for Kubernetes and Google Cloud
- add `dagster.yaml` and `dagster_gke.yaml` configurations
- expose `gke_defs` Definitions with a GCS IO manager
- add workspace file and docs for running on GKE

## Testing
- `black swmaps/gke_defs.py swmaps/__init__.py pyproject.toml -q`
- `isort swmaps/gke_defs.py swmaps/__init__.py pyproject.toml`
- `ruff check swmaps/gke_defs.py swmaps/__init__.py`
- ❌ `pre-commit run` *(failed: could not access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68673343f9a8832a8c060fd9bc35c42a