### PR TITLE
Add type hints to various modules

### DIFF
--- a/pipeline_runner.py
+++ b/pipeline_runner.py
@@ -24,7 +24,7 @@ from swmaps.core.salinity_tools import (
 from swmaps.core.water_trend import load_wet_year, pixel_trend, plot_trend_heatmap
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Saltwater Intrustion Detection Runner"
     )

--- a/swmaps/config.py
+++ b/swmaps/config.py
@@ -1,5 +1,6 @@
 # swmaps/config.py
 from pathlib import Path
+from os import PathLike
 
 from pydantic import Field
 from pydantic_settings import BaseSettings
@@ -18,6 +19,7 @@ class Settings(BaseSettings):
 settings = Settings()
 
 
-def data_path(*parts) -> Path:
-    """Convenience for building paths inside the data_root."""
+def data_path(*parts: str | PathLike[str]) -> Path:
+    """Convenience for building paths inside the :data:`data_root`."""
+
     return settings.data_root.joinpath(*parts)

--- a/swmaps/core/aoi.py
+++ b/swmaps/core/aoi.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from typing import Iterable, Sequence
+
 import geopandas as gpd
 import numpy as np
 from shapely.geometry import MultiPolygon, Polygon, box
 
 
-def to_polygon(aoi):
+def to_polygon(aoi: Sequence[float] | Polygon | MultiPolygon) -> Polygon | MultiPolygon:
     """
     Accepts either a 4-tuple bbox or a shapely polygon (EPSG:4326).
     Returns a shapely Polygon/MultiPolygon (still in EPSG:4326).
@@ -23,10 +25,10 @@ def to_polygon(aoi):
 
 
 def iter_square_patches(
-    aoi,
-    patch_size_m,
-    metric_crs="EPSG:32618",
-):
+    aoi: Sequence[float] | Polygon | MultiPolygon,
+    patch_size_m: float,
+    metric_crs: str = "EPSG:32618",
+) -> Iterable[Polygon]:
     """
     Yield **patch polygons in metric_crs** that intersect the AOI.
 

--- a/swmaps/core/salinity_tools.py
+++ b/swmaps/core/salinity_tools.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Sequence
 
 import joblib
 import numpy as np
@@ -21,11 +22,11 @@ def _default_wod_example() -> Path:
 
 
 def build_salinity_truth(
-    dataset_files=None,
-    output_csv=None,
-    depth=1.0,
-    prof_limit=None,
-):
+    dataset_files: Sequence[str | Path] | None = None,
+    output_csv: str | Path | None = None,
+    depth: float = 1.0,
+    prof_limit: int | None = None,
+) -> None:
     dataset_files = (
         list(dataset_files) if dataset_files is not None else [_default_wod_example()]
     )
@@ -135,7 +136,7 @@ def build_salinity_truth(
         print("......")
 
 
-def load_salinity_truth(truth_file=None):
+def load_salinity_truth(truth_file: str | Path | None = None) -> pd.DataFrame:
     truth_file = (
         Path(truth_file)
         if truth_file
@@ -147,15 +148,15 @@ def load_salinity_truth(truth_file=None):
 
 
 def process_salinity_features_chunk(
-    src,
-    win,
-    band_index,
-    src_lbl=None,
-    dst_y=None,
-    dst_y_win=None,
-    water_threshold=0.2,
-    profile=None,
-):
+    src: rasterio.io.DatasetReader,
+    win: Window,
+    band_index: dict[str, int],
+    src_lbl: rasterio.io.DatasetReader | None = None,
+    dst_y: rasterio.io.DatasetWriter | None = None,
+    dst_y_win: Window | None = None,
+    water_threshold: float = 0.2,
+    profile: dict | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
     """Read bands and compute feature stack, water mask, and optionally write labels for a given window."""
     blue = src.read(band_index["blue"], window=win)
     green = src.read(band_index["green"], window=win)
@@ -204,15 +205,15 @@ def process_salinity_features_chunk(
 
 
 def extract_salinity_features_from_mosaic(
-    mosaic_path,
-    mission_band_index,
-    output_feature_path,
-    output_mask_path,
-    label_path=None,
-    output_label_path=None,
-    chunk_size=512,
-    water_threshold=0.2,
-):
+    mosaic_path: str | Path,
+    mission_band_index: dict[str, int],
+    output_feature_path: str | Path,
+    output_mask_path: str | Path,
+    label_path: str | Path | None = None,
+    output_label_path: str | Path | None = None,
+    chunk_size: int = 512,
+    water_threshold: float = 0.2,
+) -> None:
     """
     Windowed salinity feature extraction and disk-based writing.
 
@@ -275,7 +276,13 @@ def extract_salinity_features_from_mosaic(
                     dst_y.close()
 
 
-def train_salinity_deng(X, y, test_size=0.2, random_state=42, save_model_path=None):
+def train_salinity_deng(
+    X: np.ndarray,
+    y: np.ndarray,
+    test_size: float = 0.2,
+    random_state: int = 42,
+    save_model_path: str | Path | None = None,
+) -> tuple[xgb.XGBRegressor, dict[str, float]]:
     """
     Train an XGBoost regressor on salinity feature data.:
     Deng et al., 2024. Monitoring Salinity in Inner Mongolian Lakes Based on Sentinel‑2 Images and Machine Learning.

--- a/swmaps/core/water_trend.py
+++ b/swmaps/core/water_trend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,7 +21,10 @@ __all__ = [
 ]
 
 
-def load_wet_year(paths, chunks=None):
+def load_wet_year(
+    paths: Sequence[str | Path],
+    chunks: dict[str, int] | None = None,
+) -> xr.DataArray:
     """Load monthly water masks and convert to yearly wet fraction.
 
     Parameters
@@ -77,13 +81,16 @@ def theil_sen_slope(ts: np.ndarray) -> np.float32:
     return np.median(slopes)
 
 
-def mk_p(ts, years):
+def mk_p(ts: np.ndarray, years: np.ndarray) -> np.float32:
     """Mann‑Kendall p‑value for a time series."""
     tau, p = kendalltau(years, ts)
     return np.float32(1.0 if np.isnan(p) else p)
 
 
-def pixel_trend(wet_year, progress=True):
+def pixel_trend(
+    wet_year: xr.DataArray,
+    progress: bool = True,
+) -> tuple[xr.DataArray, xr.DataArray]:
     """Calculate per‑pixel Theil–Sen slope and MK p‑value.
 
     Parameters
@@ -134,13 +141,13 @@ def pixel_trend(wet_year, progress=True):
 
 
 def plot_trend_heatmap(
-    slope,
-    signif,
-    vmin=-0.05,
-    vmax=0.05,
-    title=None,
-    ax=None,
-):
+    slope: xr.DataArray,
+    signif: xr.DataArray,
+    vmin: float = -0.05,
+    vmax: float = 0.05,
+    title: str | None = None,
+    ax: plt.Axes | None = None,
+) -> plt.Axes:
     """Plot a heatmap of water trend with significance mask."""
     if ax is None:
         fig, ax = plt.subplots(figsize=(10, 8))

--- a/swmaps/pipelines/assets.py
+++ b/swmaps/pipelines/assets.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import geopandas as gpd
 from dagster import (
+    AssetExecutionContext,
     StaticPartitionsDefinition,
     asset,
 )
@@ -61,7 +62,7 @@ _LS7_TIF = data_path("landsat7_eastern_shore.tif")
     partitions_def=partitions_def,
     io_manager_key="local_files",  # swap to gcs_io_manager in prod
 )
-def masks_by_range(context) -> list[str]:
+def masks_by_range(context: AssetExecutionContext) -> list[str]:
     """Materialise NDWI water masks for a single date range (e.g. 1984‑03‑01/1984‑03‑31)."""
 
     date_range: str = context.partition_key  # already in the correct "start/end" form
@@ -97,7 +98,7 @@ def masks_by_range(context) -> list[str]:
     partitions_def=partitions_def,
     io_manager_key="local_files",  # swap to gcs_io_manager in prod
 )
-def download_range(context) -> list[str]:
+def download_range(context: AssetExecutionContext) -> list[str]:
     """Materialise NDWI water masks for a single date range (e.g. 1984‑03‑01/1984‑03‑31)."""
 
     date_range: str = context.partition_key  # already in the correct "start/end" form


### PR DESCRIPTION
## Summary
- annotate helper `data_path`
- add type hints for AOI utilities
- type annotate water trend helpers
- add annotations for salinity tools
- update asset functions with typed context
- begin annotating download tools
- tweak CLI entrypoint signature

## Testing
- `pre-commit run --files pipeline_runner.py swmaps/config.py swmaps/core/aoi.py swmaps/core/download_tools.py swmaps/core/salinity_tools.py swmaps/core/water_trend.py swmaps/pipelines/assets.py` *(fails: CalledProcessError)*

------
https://chatgpt.com/codex/tasks/task_e_6876854896ac832a8da13e118bfadc7f