### PR TITLE
Add minimal test suite

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import importlib.util
+
+import pytest
+
+pytest.importorskip('pydantic_settings')
+
+# Import swmaps.config without executing swmaps.__init__
+CONFIG_PATH = Path(__file__).resolve().parents[1] / 'swmaps' / 'config.py'
+spec = importlib.util.spec_from_file_location('swmaps.config', CONFIG_PATH)
+config = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(config)
+
+
+def test_data_path_default():
+    root = config.settings.data_root
+    assert config.data_path('subdir', 'file.txt') == root / 'subdir' / 'file.txt'
+
+
+def test_data_path_env_override(monkeypatch):
+    tmp_root = Path('temp_data_root')
+    monkeypatch.setenv('SW_DATA_ROOT', str(tmp_root))
+    import importlib
+    importlib.reload(config)
+    assert config.settings.data_root == tmp_root
+    assert config.data_path('a') == tmp_root / 'a'
+    monkeypatch.delenv('SW_DATA_ROOT', raising=False)
+    importlib.reload(config)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,22 @@
+import importlib
+import pytest
+
+pytest.importorskip('shapely')
+pytest.importorskip('geopandas')
+
+from swmaps.core import aoi
+
+
+def test_to_polygon_bbox():
+    poly = aoi.to_polygon([0, 0, 1, 1])
+    from shapely.geometry import Polygon
+    assert isinstance(poly, Polygon)
+    assert poly.bounds == (0.0, 0.0, 1.0, 1.0)
+
+
+def test_iter_square_patches_simple():
+    patches = list(aoi.iter_square_patches([0, 0, 2, 2], 1.0, metric_crs='EPSG:3857'))
+    assert len(patches) > 0
+    from shapely.geometry import Polygon
+    for p in patches:
+        assert isinstance(p, Polygon)

--- a/tests/test_water_trend.py
+++ b/tests/test_water_trend.py
@@ -1,0 +1,30 @@
+import importlib
+import pytest
+
+np = pytest.importorskip('numpy')
+xr = pytest.importorskip('xarray')
+
+from swmaps.core import water_trend
+
+
+def test_theil_sen_slope_linear():
+    data = np.array([0, 1, 2, 3, 4], dtype=np.float32)
+    slope = water_trend.theil_sen_slope(data)
+    assert slope == pytest.approx(1.0)
+
+
+def test_mk_p_trend():
+    ts = np.array([0, 1, 2, 3, 4], dtype=np.float32)
+    years = np.arange(5, dtype=np.float32)
+    p = water_trend.mk_p(ts, years)
+    assert 0 <= p <= 1
+
+
+def test_pixel_trend_small():
+    arr = xr.DataArray(
+        np.stack([np.zeros((2,2), dtype=np.float32), np.ones((2,2), dtype=np.float32)]),
+        dims=("time", "y", "x"),
+    )
+    slope, pval = water_trend.pixel_trend(arr, progress=False)
+    assert slope.shape == (2,2)
+    assert pval.shape == (2,2)


### PR DESCRIPTION
## Summary
- add `tests` directory with initial pytest suites
- tests rely on optional deps and skip when unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876a05dfb70832abbba91d0a74e3bd8