### PR TITLE
Add trend output saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,19 @@ This salinity dataset enables spatial validation and supervised learning, bridgi
 Use `swmaps.core.water_trend` to model how long each pixel stays water-covered and how that changes over time.
 
 ```python
-from swmaps.core.water_trend import load_wet_year, pixel_trend, plot_trend_heatmap
+from swmaps.core.water_trend import (
+    load_wet_year,
+    pixel_trend,
+    plot_trend_heatmap,
+    save_trend_results,
+)
 
 wet_year = load_wet_year("masks/*.tif")
 slope, pval = pixel_trend(wet_year)
 signif = pval < 0.05
 plot_trend_heatmap(slope, signif, title="Trend in % wet months per year")
+# Save arrays to GeoTIFF and NumPy for later inspection
+save_trend_results(slope, pval, "water_trend")
 ```
 
 

--- a/pipeline_runner.py
+++ b/pipeline_runner.py
@@ -21,7 +21,12 @@ from swmaps.core.salinity_tools import (
     extract_salinity_features_from_mosaic,
     load_salinity_truth,
 )
-from swmaps.core.water_trend import load_wet_year, pixel_trend, plot_trend_heatmap
+from swmaps.core.water_trend import (
+    load_wet_year,
+    pixel_trend,
+    plot_trend_heatmap,
+    save_trend_results,
+)
 
 
 def main() -> None:
@@ -219,6 +224,8 @@ def main() -> None:
             heatmap_file = data_path("water_trend_heatmap.png")
             ax.figure.savefig(heatmap_file, bbox_inches="tight")
             print(f"Saved trend heatmap to {heatmap_file}")
+
+            save_trend_results(slope, pval, data_path("water_trend"))
         else:
             print("No mask files found for water trend analysis")
         return


### PR DESCRIPTION
## Summary
- save per-pixel trend results for review
- expose new helper and document usage

## Testing
- `pre-commit run --files swmaps/core/water_trend.py pipeline_runner.py README.md` *(fails: unable to fetch git repo for pre‑commit hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6876ebf359b0832aa4c96767734c5cd2