### PR TITLE
Handle optional deps for tests

### DIFF
--- a/swmaps/__init__.py
+++ b/swmaps/__init__.py
@@ -1,15 +1,22 @@
 # swmaps/__init__.py
 
-from dagster import Definitions, fs_io_manager
+try:
+    from dagster import Definitions, fs_io_manager
+except Exception:  # pragma: no cover - allow missing optional dependency
+    Definitions = None  # type: ignore[assignment]
+    fs_io_manager = None  # type: ignore[assignment]
 
-from .pipelines.assets import download_range, masks_by_range
-from .pipelines.resources import data_root_res
+if Definitions is not None:
+    from .pipelines.assets import download_range, masks_by_range
+    from .pipelines.resources import data_root_res
 
-# Expose all pipeline assets for local execution with a filesystem IO manager.
-defs = Definitions(
-    assets=[download_range, masks_by_range],
-    resources={
-        "data_root": data_root_res,
-        "local_files": fs_io_manager,
-    },
-)
+    # Expose all pipeline assets for local execution with a filesystem IO manager.
+    defs = Definitions(
+        assets=[download_range, masks_by_range],
+        resources={
+            "data_root": data_root_res,
+            "local_files": fs_io_manager,
+        },
+    )
+else:  # pragma: no cover - dagster is optional for non-pipeline usage
+    defs = None

--- a/swmaps/config.py
+++ b/swmaps/config.py
@@ -3,27 +3,40 @@ from os import PathLike
 from pathlib import Path
 
 from pydantic import Field
-from pydantic_settings import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except Exception:  # pragma: no cover - optional dependency
+    BaseSettings = None  # type: ignore[assignment]
 
 
-class Settings(BaseSettings):
-    # Can be overridden with SW_DATA_ROOT=/mnt/bucket or helm env var
-    data_root: Path = Field(
-        default_factory=lambda: Path(__file__).resolve().parent / "data"
-    )
+if BaseSettings is not None:
+    class Settings(BaseSettings):
+        # Can be overridden with SW_DATA_ROOT=/mnt/bucket or helm env var
+        data_root: Path = Field(
+            default_factory=lambda: Path(__file__).resolve().parent / "data"
+        )
 
-    class Config:
-        env_prefix = "SW_"
+        class Config:
+            env_prefix = "SW_"
+else:  # pragma: no cover - optional dependency missing
+    Settings = None  # type: ignore[assignment]
 
 
 def get_settings():
+    if Settings is None:
+        raise RuntimeError("pydantic_settings is required for get_settings")
     return Settings()
 
 
-settings = Settings()
+if Settings is not None:
+    settings = Settings()
+else:  # pragma: no cover - optional dependency missing
+    settings = None
 
 
 def data_path(*parts: str | PathLike[str]) -> Path:
     """Convenience for building paths inside the :data:`data_root`."""
 
+    if settings is None:
+        raise RuntimeError("pydantic_settings is required for data_path")
     return settings.data_root.joinpath(*parts)


### PR DESCRIPTION
## Summary
- make Dagster import optional in `swmaps.__init__`
- guard configuration module on missing `pydantic_settings`
- allow `water_trend` module to load without optional packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687af702cf24832ab618fd1687e1fa55