### PR TITLE
Configure workflow outputs via configurable data root

### DIFF
--- a/swmaps/config.py
+++ b/swmaps/config.py
@@ -49,6 +49,20 @@ def get_settings() -> Settings:
 settings = Settings()
 
 
+def set_data_root(path: str | PathLike[str] | Path) -> None:
+    """Override the global data root used for pipeline artifacts.
+
+    Args:
+        path (str | os.PathLike | Path): Directory to use as the base for
+            :func:`data_path` resolutions.
+
+    Returns:
+        None
+    """
+
+    settings.data_root = Path(path)
+
+
 def data_path(*parts: str | PathLike[str]) -> Path:
     """Convenience for building paths inside the :data:`data_root`.
 

--- a/swmaps/pipeline/coastal.py
+++ b/swmaps/pipeline/coastal.py
@@ -2,29 +2,34 @@
 
 from pathlib import Path
 
-import geopandas as gpd
-
 from swmaps.core.coastline import create_coastal_poly
 
 
-def create_coastal(use_bbox: bool = False) -> None:
+def create_coastal(
+    use_bbox: bool = False, output_root: str | Path | None = None
+) -> None:
     """Create the study coastal polygon or bounding-box region.
 
     Args:
         use_bbox (bool): If ``True``, load the configured bounding box instead
             of generating the buffered coastal polygon.
+        output_root (str | Path | None): Directory where the generated
+            ``coastal_band.gpkg`` should be written. When ``None``, defaults to
+            the project ``config/`` directory.
 
     Returns:
-        None: Output files are written under ``config/``.
+        None: Output files are written under ``output_root`` or ``config/``.
     """
-    if use_bbox:
-        geojson = Path(__file__).resolve().parents[2] / "config" / "somerset.geojson"
-        gdf = gpd.read_file(geojson)
-        if gdf.crs != "EPSG:4326":
-            gdf = gdf.to_crs("EPSG:4326")
-        geojson = geojson
-    else:
-        geojson = Path(__file__).resolve().parents[2] / "config" / "coastal_band.gpkg"
+    config_dir = Path(__file__).resolve().parents[2] / "config"
+    bbox_file = (
+        config_dir / "somerset.geojson"
+        if use_bbox
+        else config_dir / "coastal_band.geojson"
+    )
+
+    destination_dir = Path(output_root) if output_root else config_dir
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    out_file = destination_dir / "coastal_band.gpkg"
 
     print("Creating Coastal Polygon")
-    create_coastal_poly(geojson)
+    create_coastal_poly(bbox_file, out_file=out_file)


### PR DESCRIPTION
## Summary
- add a helper to override the pipeline data root at runtime
- update the workflow runner to honour the config `output_root` for all steps
- allow coastal polygon generation to write into the configured output directory

## Testing
- python -m compileall swmaps/pipeline/coastal.py examples/workflow_runner.py swmaps/config.py

------
https://chatgpt.com/codex/tasks/task_e_68e70fafe434832a97372e8c54b7f868