### PR TITLE
Skip redundant salinity downloads and processing

### DIFF
--- a/swmaps/core/salinity/utils.py
+++ b/swmaps/core/salinity/utils.py
@@ -134,6 +134,9 @@ def build_salinity_truth(
         if output_csv
         else data_path("salinity_labels", "codc_salinity_profiles.csv")
     )
+    if output_csv.exists() and output_csv.stat().st_size > 0:
+        logging.info("Salinity truth CSV already exists at %s; skipping rebuild", output_csv)
+        return
     output_csv.parent.mkdir(parents=True, exist_ok=True)
 
     lat_idx = 4
@@ -364,6 +367,18 @@ def extract_salinity_features_from_mosaic(
     Returns:
         None: Outputs are written to disk.
     """
+
+    output_feature_path = Path(output_feature_path)
+    output_mask_path = Path(output_mask_path)
+    output_label_path = Path(output_label_path) if output_label_path else None
+
+    outputs_exist = output_feature_path.exists() and output_mask_path.exists()
+    if outputs_exist and (output_label_path is None or output_label_path.exists()):
+        logging.info(
+            "Salinity features already exist for %s; skipping extraction",
+            mosaic_path,
+        )
+        return
 
     with rasterio.open(mosaic_path) as src:
         profile = src.profile.copy()

--- a/tests/test_salinity_utils.py
+++ b/tests/test_salinity_utils.py
@@ -1,0 +1,45 @@
+"""Tests for salinity utility helper safeguards."""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from swmaps.core.salinity import utils
+
+
+def test_build_salinity_truth_skips_when_output_exists(tmp_path: Path) -> None:
+    """If the truth CSV already exists, the builder should not redo work."""
+
+    output_csv = tmp_path / "existing_truth.csv"
+    output_csv.write_text("dummy")
+
+    # Should return early without raising even if no datasets are supplied.
+    utils.build_salinity_truth(dataset_files=[], output_csv=output_csv)
+
+    assert output_csv.read_text() == "dummy"
+
+
+def test_extract_salinity_features_skip_when_outputs_exist(tmp_path: Path) -> None:
+    """Feature extraction should be skipped when outputs are already on disk."""
+
+    feature_path = tmp_path / "features.tif"
+    mask_path = tmp_path / "mask.tif"
+    feature_path.write_bytes(b"")
+    mask_path.write_bytes(b"")
+
+    # No mosaic is needed because the function should return early.
+    with pytest.raises(FileNotFoundError):
+        Path("nonexistent").resolve(strict=True)
+
+    utils.extract_salinity_features_from_mosaic(
+        mosaic_path="nonexistent-mosaic.tif",
+        mission_band_index={},
+        output_feature_path=feature_path,
+        output_mask_path=mask_path,
+    )
+
+    # Files should remain untouched (still empty) after the no-op call.
+    assert feature_path.read_bytes() == b""
+    assert mask_path.read_bytes() == b""


### PR DESCRIPTION
## Summary
- skip rebuilding the salinity truth CSV when an existing file is detected
- avoid reprocessing mosaics that already have salinity features and mask outputs
- add regression coverage for the new early-return safeguards

## Testing
- pytest tests/test_salinity_utils.py *(skipped: requires pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfea42a44832ab1f381b4729fb5f7