### PR TITLE
Add CNN utilities for NLCD landcover prediction

### DIFF
--- a/swmaps/core/nlcd/nlcdcnn.py
+++ b/swmaps/core/nlcd/nlcdcnn.py
@@ -94,7 +94,8 @@ def train_model(
                 val_labels.extend(labels.cpu().numpy())
 
         val_acc = accuracy_score(val_labels, val_preds)
-        print(
+        import logging
+        logging.info(
             f"Epoch {epoch + 1}/{num_epochs}, "
             f"Train Loss: {total_loss / len(train_loader):.4f}, "
             f"Val Acc: {val_acc:.3f}"


### PR DESCRIPTION
## Summary
- add a convolutional neural network module for NLCD land-cover classification
- include training, evaluation, and dataset helpers mirroring the salinity CNN utilities

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe495f3f70832a8024e79d42cb2421